### PR TITLE
remove pause-time-while-still-rendering function

### DIFF
--- a/components/buttons/playpausebutton.tsx
+++ b/components/buttons/playpausebutton.tsx
@@ -3,8 +3,7 @@ import PlayCircleOutlineIcon from '@mui/icons-material/PlayCircleOutline';
 import Button from '@mui/material/Button';
 import { useTheme } from '@mui/material/styles';
 import { useAtom, useAtomValue } from 'jotai';
-import { pauseTimeWhileStillRenderingAtom, playAtom } from 'lib/atoms/atoms';
-import { useEffect, useState } from 'react';
+import { playAtom } from 'lib/atoms/atoms';
 
 const PlayPauseIcon = () => {
     const play = useAtomValue(playAtom);
@@ -13,47 +12,17 @@ const PlayPauseIcon = () => {
 
 export const PlayPauseButton = () => {
     const [play, setPlay] = useAtom(playAtom);
-    const [pauseTimeWhileStillRendering, setPauseTimeWhileStillRendering] = useAtom(
-        pauseTimeWhileStillRenderingAtom
-    );
-    const [ctrlKeyDown, setCtrlKeyDown] = useState(false);
     const theme = useTheme();
-
-    useEffect(() => {
-        const listenForCtrlKeyPress = e => {
-            if (e.code === 'ControlLeft' || e.metaKey) {
-                // will this work on mac?
-                setCtrlKeyDown(true);
-            }
-        };
-        const listenForCtrlKeyUnpress = e => {
-            if (e.code === 'ControlLeft' || e.metaKey) {
-                // will this work on mac?
-                setCtrlKeyDown(false);
-            }
-        };
-        window.addEventListener('keydown', listenForCtrlKeyPress);
-        window.addEventListener('keyup', listenForCtrlKeyUnpress);
-        return () => {
-            window.removeEventListener('keydown', listenForCtrlKeyPress);
-            window.removeEventListener('keyup', listenForCtrlKeyUnpress);
-        };
-    });
 
     return (
         <Button
             onClick={() => {
-                if (ctrlKeyDown && play === true) {
-                    setPauseTimeWhileStillRendering(true);
-                }
                 setPlay(!play);
             }}
-            title={'Play/Pause <Ctrl + Alt + Up> \nPause Time, but keep rendering <Ctrl + Click>'}
+            title={'Play/Pause <Ctrl + Alt + Up>\n'}
             sx={
                 play
                     ? { color: theme.palette.primary.contrastText }
-                    : pauseTimeWhileStillRendering
-                    ? { color: 'orange' }
                     : { color: theme.palette.primary.light }
             }
         >

--- a/components/wgputoycontroller.tsx
+++ b/components/wgputoycontroller.tsx
@@ -13,7 +13,6 @@ import {
     loadedTexturesAtom,
     manualReloadAtom,
     parseErrorAtom,
-    pauseTimeWhileStillRenderingAtom,
     playAtom,
     recordingAtom,
     requestFullscreenAtom,
@@ -48,9 +47,6 @@ const needsInitialResetAtom = atom<boolean>(false);
  */
 const WgpuToyController = props => {
     const [play, setPlay] = useAtom(playAtom);
-    const [pauseTimeWhileStillRendering, setPauseTimeWhileStillRendering] = useAtom(
-        pauseTimeWhileStillRenderingAtom
-    );
     const [reset, setReset] = useAtom(resetAtom);
     const hotReload = useAtomValue(hotReloadAtom);
     const [recording, setRecording] = useAtom(recordingAtom);
@@ -161,7 +157,7 @@ const WgpuToyController = props => {
             } else {
                 liveReloadCallback();
             }
-            if (pauseTimeWhileStillRendering || (sliderUpdateSignal() && !isPlaying())) {
+            if (sliderUpdateSignal() && !isPlaying()) {
                 wgputoy.set_time_delta(e.delta);
                 wgputoy.render();
             } else if (isPlaying() || manualReload()) {
@@ -396,7 +392,6 @@ const WgpuToyController = props => {
     useEffect(() => {
         if (play && !isPlaying()) {
             playCallback();
-            setPauseTimeWhileStillRendering(false);
         } else if (!play && isPlaying()) {
             pauseCallback();
         }

--- a/lib/atoms/atoms.tsx
+++ b/lib/atoms/atoms.tsx
@@ -48,7 +48,6 @@ export type WgpuStatus = 'available' | 'unavailable' | 'unknown';
 export const wgpuAvailabilityAtom = atom<WgpuStatus>('unknown');
 
 export const playAtom = atom<boolean>(true);
-export const pauseTimeWhileStillRenderingAtom = atom<boolean>(false);
 export const resetAtom = atom<boolean>(false);
 export const hotReloadAtom = atom<boolean>(false);
 export const manualReloadAtom = atom<boolean>(false);


### PR DESCRIPTION
I think it's useless now that re-renders are triggered by clicking on the viewport or dragging uniform sliders.