### PR TITLE
graceful crash for iOS & Linux

### DIFF
--- a/components/editor/preludeshim.tsx
+++ b/components/editor/preludeshim.tsx
@@ -1,18 +1,20 @@
 import { useAtomValue } from 'jotai';
-import { isSafeContext, wgputoyAtom } from 'lib/atoms/wgputoyatoms';
+import { wgpuAvailabilityAtom, wgputoyAtom } from 'lib/atoms/wgputoyatoms';
 import { Fragment, useEffect, useState } from 'react';
 
 /*
     We need to put this in its own component because any access to wgpu
     data must be through dynamic imports (i.e. client-side only)
-    Is there a less bogus way of doing this??
  */
 export default function PreludeShim() {
-    const wgpuToy = useAtomValue(wgputoyAtom);
+    const wgpuAvailability = useAtomValue(wgpuAvailabilityAtom);
     const [prelude, setPrelude] = useState('');
 
+    const wgpuToy = useAtomValue(wgputoyAtom);
     useEffect(() => {
-        setPrelude(isSafeContext(wgpuToy) ? wgpuToy.prelude() : '');
+        if (wgpuAvailability === 'available' && wgpuToy) {
+            setPrelude(wgpuToy.prelude());
+        }
     }, [wgpuToy]);
 
     return <Fragment>{prelude}</Fragment>;

--- a/components/global/nowgpumodal.tsx
+++ b/components/global/nowgpumodal.tsx
@@ -3,7 +3,7 @@ import Modal from '@mui/material/Modal';
 import Stack from '@mui/material/Stack';
 import Typography from '@mui/material/Typography';
 import { useAtomValue } from 'jotai';
-import { wgpuAvailabilityAtom } from 'lib/atoms/atoms';
+import { wgpuAvailabilityAtom } from 'lib/atoms/wgputoyatoms';
 import { Fragment, useEffect, useState } from 'react';
 import { theme } from 'theme/theme';
 import Logo from './logo';

--- a/lib/atoms/atoms.tsx
+++ b/lib/atoms/atoms.tsx
@@ -41,12 +41,6 @@ export interface Texture {
     url?: string;
 }
 
-export type Visibility = 'private' | 'unlisted' | 'public';
-
-export type WgpuStatus = 'available' | 'unavailable' | 'unknown';
-
-export const wgpuAvailabilityAtom = atom<WgpuStatus>('unknown');
-
 export const playAtom = atom<boolean>(true);
 export const resetAtom = atom<boolean>(false);
 export const hotReloadAtom = atom<boolean>(false);
@@ -74,6 +68,8 @@ export const shaderIDAtom = atomWithReset<number | false>(false);
 export const codeAtom = atomWithReset<string>(DEFAULT_SHADER);
 export const titleAtom = atomWithReset<string>('New Shader');
 export const descriptionAtom = atomWithReset<string>('');
+
+export type Visibility = 'private' | 'unlisted' | 'public';
 export const visibilityAtom = atomWithReset<Visibility>('private');
 export const loadedTexturesAtom = atomWithReset<Texture[]>([
     { img: '/textures/blank.png' },

--- a/lib/atoms/wgputoyatoms.tsx
+++ b/lib/atoms/wgputoyatoms.tsx
@@ -24,6 +24,9 @@ export const canvasParentElAtom = atom<HTMLElement | null, HTMLElement | null, v
     (get, set, newValue) => set(canvasParentElBaseAtom, newValue ? newValue : false)
 );
 
+export type WgpuStatus = 'available' | 'unavailable' | 'unknown';
+export const wgpuAvailabilityAtom = atom<WgpuStatus>('unknown');
+
 export const wgputoyAtom = atom<Promise<WgpuToyRenderer | false>>(async get => {
     // https://github.com/webpack/webpack/issues/11347
     const wasm = await import('lib/wgputoy/wgputoy_bg.wasm');

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "@react-hook/resize-observer": "^1.2.5",
     "@supabase/gotrue-js": "^1.22.13",
     "@supabase/supabase-js": "^1.35.2",
+    "@webgpu/types": "^0.1.34",
     "base64-arraybuffer": "^1.0.2",
     "firacode": "^6.2.0",
     "jotai": "^1.6.4",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -20,7 +20,8 @@
     "resolveJsonModule": true,
     "isolatedModules": true,
     "sourceMap": true,
-    "jsx": "preserve"
+    "jsx": "preserve",
+    "types": ["@webgpu/types"]
   },
   "include": [
     "next-env.d.ts",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2771,6 +2771,11 @@
   resolved "https://registry.yarnpkg.com/@web3-storage/multipart-parser/-/multipart-parser-1.0.0.tgz#6b69dc2a32a5b207ba43e556c25cc136a56659c4"
   integrity sha512-BEO6al7BYqcnfX15W2cnGR+Q566ACXAT9UQykORCWW80lmkpWsnEob6zJS1ZVBKsSJC8+7vJkHwlp+lXG1UCdw==
 
+"@webgpu/types@^0.1.34":
+  version "0.1.34"
+  resolved "https://registry.yarnpkg.com/@webgpu/types/-/types-0.1.34.tgz#4537c9cae874a63ef79d7afdc2c36a792581d4ad"
+  integrity sha512-9mXtH+CC8q+Ku7Z+1XazNIte81FvfdXwR2lLRO7Ykzjd/hh1J1krJa0gtnkF1kvP11psUmKEPKo7iMTeEcUpNA==
+
 abbrev@1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/abbrev/-/abbrev-1.1.1.tgz#f8f2c887ad10bf67f634f005b6987fed3179aac8"


### PR DESCRIPTION
What this PR do:
* when application crashed it is showing the shader code and iPhone users can read it
* refactor: put wgpuAvailabilityAtom to wgputoyatoms
* add WebGPU types for typescript