### PR TITLE
Fix texture picker clipping

### DIFF
--- a/components/editor/texturepicker.tsx
+++ b/components/editor/texturepicker.tsx
@@ -58,11 +58,7 @@ const DraggablePicker = props => {
                         color={'primary'}
                     />
                 </div>
-                <ImageList
-                    sx={{ width: size * 6, height: size * 4, overflow: 'hidden' }}
-                    cols={6}
-                    rowHeight={size}
-                >
+                <ImageList sx={{ overflow: 'hidden' }} cols={6} rowHeight={size}>
                     {defaultTextures.map(item => (
                         <ImageListItem
                             key={item.img + props.channel}


### PR DESCRIPTION
This fixes clipping that occurs in the rightmost column of texture previews in the drag-and-drop texture picker. The size of the window was overridden as `size [px] * 6 [num. columns]`, which does not factor in the default 4px of grid gap included with `ImageList`.

Overflow demo:

![image](https://github.com/user-attachments/assets/a4aac774-66fb-4917-adc9-8a02fd33ab5a)

Old:

![image](https://github.com/user-attachments/assets/738cc4a9-e247-4884-b0c8-1d9f69cb026a)


New:

![image](https://github.com/user-attachments/assets/7274219f-7258-482b-a9f9-b60d5fc377ba)

