### PR TITLE
Bugfix: Add external linking to allowed domains

### DIFF
--- a/components/global/allowedtexturesources.tsx
+++ b/components/global/allowedtexturesources.tsx
@@ -22,6 +22,8 @@ export default function AllowedTextureSources() {
                         secondaryAction={
                             <IconButton
                                 role="link"
+                                target="_blank"
+                                href={resource.referenceUrl}
                                 aria-label={`Open URL for ${resource.displayName}`}
                                 sx={{
                                     minWidth: '1em',


### PR DESCRIPTION
When I implemented https://github.com/compute-toys/compute.toys/pull/86 I intended the link buttons on the allowed domains list to link to a "homepage" for each image source, hopefully assisting users in finding their own custom textures. The actual href attribute didn't make it in, so adding it here.