### PR TITLE
Feature: Draggable window improvements

### DIFF
--- a/components/editor/explainer.tsx
+++ b/components/editor/explainer.tsx
@@ -211,7 +211,11 @@ export default function Explainer() {
             >
                 <QuestionMarkIcon />
             </Button>
-            <DraggableWindow hidden={explainerHidden} setHidden={setExplainerHidden}>
+            <DraggableWindow
+                hidden={explainerHidden}
+                setHidden={setExplainerHidden}
+                sx={{ paddingTop: '8px' }}
+            >
                 <ExplainerBody />
             </DraggableWindow>
         </Fragment>

--- a/components/editor/explainer.tsx
+++ b/components/editor/explainer.tsx
@@ -1,256 +1,199 @@
 'use client';
-import DisabledByDefaultSharp from '@mui/icons-material/DisabledByDefaultSharp';
 import QuestionMarkIcon from '@mui/icons-material/QuestionMark';
 import Button from '@mui/material/Button';
 import { useTheme } from '@mui/material/styles';
 import { useAtomValue } from 'jotai';
 import { wgputoyPreludeAtom } from 'lib/atoms/wgputoyatoms';
 import Link from 'next/link';
-import { Fragment, useRef, useState } from 'react';
-import Draggable from 'react-draggable';
-import { Item } from 'theme/theme';
+import { Fragment, useState } from 'react';
+
+import DraggableWindow from '../global/draggable-window';
 import { HiLite } from '../global/hilite';
 import Logo from '../global/logo';
 
-const EXPLAINER_HEIGHT = '600';
 const EXPLAINER_INNER_HEIGHT = '570';
 
-const DraggableExplainer = props => {
+const ExplainerBody = () => {
     const theme = useTheme();
     const prelude = useAtomValue(wgputoyPreludeAtom);
 
-    // Draggable needs this so React doesn't complain
-    // about violating strict mode DOM access rules
-    const nodeRef = useRef(null);
-
     return (
-        <Draggable
-            handle=".explainer-handle"
-            nodeRef={nodeRef}
-            bounds="body"
-            positionOffset={{ x: '0', y: '0' }}
+        <div
+            style={{
+                textAlign: 'left',
+                width: 'min-content',
+                overflowY: 'auto',
+                padding: '8px',
+                height: `${EXPLAINER_INNER_HEIGHT}px`,
+                color: theme.palette.primary.main
+            }}
         >
-            <Item
-                ref={nodeRef}
-                elevation={12}
-                sx={
-                    props.hidden
-                        ? { display: 'none' }
-                        : {
-                              zIndex: '2',
-                              display: 'inline-block',
-                              position: 'fixed',
-                              left: '12%',
-                              top: '12%',
-                              textAlign: 'left',
-                              height: `${EXPLAINER_HEIGHT}px`
-                          }
-                }
-            >
-                <div
-                    style={{
-                        display: 'flex',
-                        justifyContent: 'end',
-                        backgroundImage:
-                            'repeating-linear-gradient(-45deg, rgba(255,255,255, 0.25), rgba(255,255,255, 0.25) 2px, transparent 1px, transparent 6px)',
-                        backgroundSize: '4px 4px'
-                    }}
-                >
-                    {/* Annoying viewbox tweak to align with drag bar*/}
-                    <div style={{ width: '100%' }} className="explainer-handle"></div>
-                    <DisabledByDefaultSharp
-                        viewBox="1.5 1.5 19.5 19.5"
-                        onClick={() => props.setHidden(true)}
-                        sx={{ cursor: 'pointer', color: 'rgba(150,150,150,1)' }}
-                    />
-                </div>
-                <div
-                    style={{
-                        width: 'min-content',
-                        overflowY: 'scroll',
-                        padding: '8px',
-                        height: `${EXPLAINER_INNER_HEIGHT}px`,
-                        color: theme.palette.primary.main
-                    }}
-                >
-                    <Logo /> is a playground for WebGPU compute shaders. Everything here is written
-                    in WGSL, which is WebGPU&apos;s native shader language. For up-to-date
-                    information on WGSL, please see the{' '}
-                    <a href="https://www.w3.org/TR/WGSL/">WGSL draft specification</a>. You can also{' '}
-                    <a href="https://google.github.io/tour-of-wgsl/">take a tour of WGSL</a>
-                    .
-                    <br />
-                    <br />
-                    <h1>Inputs</h1>
-                    <Logo /> supplies keyboard input, mouse input, selectable input textures, custom
-                    values controlled by sliders, and the current frame and elapsed time.
-                    <br />
-                    <br />
-                    Mouse input can be accessed from the <HiLite>mouse</HiLite> struct:
-                    <pre style={{ color: theme.palette.neutral.main }}>
-                        mouse.pos: vec2i
-                        <br />
-                        mouse.click: i32
-                    </pre>
-                    Timing information is in the <HiLite>time</HiLite> struct:
-                    <pre style={{ color: theme.palette.neutral.main }}>
-                        time.frame: u32
-                        <br />
-                        time.elapsed: f32
-                    </pre>
-                    Custom uniforms are in the <HiLite>custom</HiLite> struct:
-                    <pre style={{ color: theme.palette.neutral.main }}>
-                        custom.my_custom_uniform_0: f32
-                        <br />
-                        custom.my_custom_uniform_1: f32
-                    </pre>
-                    Two selectable textures can be accessed from <HiLite>channel0</HiLite> and{' '}
-                    <HiLite>channel1</HiLite>:
-                    <pre style={{ color: theme.palette.neutral.main }}>
-                        textureSampleLevel(channel0, bilinear, uv, pass, lod)
-                        <br />
-                        textureSampleLevel(channel1, bilinear, uv, pass, lod)
-                    </pre>
-                    Keyboard input can be accessed from the provided{' '}
-                    <HiLite>keyDown(keycode: u32)</HiLite> helper function:
-                    <pre style={{ color: theme.palette.neutral.main }}>
-                        keyDown(32) // returns true when the spacebar is pressed
-                    </pre>
-                    <h1>Outputs</h1>
-                    For compute shader input and output <Logo /> provides:
-                    <br />
-                    one input texture array <HiLite>pass_in</HiLite>,<br />
-                    one output storage texture array <HiLite>pass_out</HiLite>,<br />
-                    and one output screen storage texture <HiLite>screen</HiLite>.
-                    <br />
-                    <br />
-                    The shader can write to <HiLite>pass_out</HiLite>, which will be copied into{' '}
-                    <HiLite>pass_in</HiLite> after the current entrypoint has returned.
-                    <HiLite> pass_in</HiLite> will always contain whatever has been written to{' '}
-                    <HiLite>pass_out</HiLite> during all of the <em>previous</em> entrypoints. The
-                    contents of <HiLite>pass_in</HiLite> will not change while an entrypoint is
-                    running.
-                    <HiLite> pass_in</HiLite> and <HiLite>pass_out</HiLite> are both texture arrays
-                    with 4 texture layers. For example, you can access the third layer of{' '}
-                    <HiLite>pass_in</HiLite> at LOD 0 and coordinate (1,1) by using the built-in
-                    helper function:
-                    <br />
-                    <pre style={{ color: theme.palette.neutral.main }}>
-                        passLoad(2, vec2i(1,1), 0)
-                    </pre>
-                    <h1>Preprocessor</h1>
-                    <Logo /> also provides an experimental WGSL preprocessor. It currently allows
-                    the use of a handful of basic directives:
-                    <ul>
-                        <li>
-                            <HiLite>#define NAME VALUE</HiLite> for simple macros (function-like
-                            parameter substitution is not yet supported)
-                        </li>
-                        <li>
-                            <HiLite>#include &quot;PATH&quot;</HiLite> for accessing built-in
-                            libraries
-                        </li>
-                        <li>
-                            <HiLite>#workgroup_count ENTRYPOINT X Y Z</HiLite> for specifying how
-                            many workgroups should be dispatched for an entrypoint
-                        </li>
-                        <li>
-                            <HiLite>#dispatch_count ENTRYPOINT N</HiLite> for dispatching an
-                            entrypoint multiple times in a row
-                        </li>
-                        <li>
-                            <HiLite>#storage NAME TYPE</HiLite> for declaring a storage buffer
-                        </li>
-                    </ul>
-                    <h1>Storage</h1>
-                    Read-write storage buffers can be declared using the <HiLite>
-                        #storage
-                    </HiLite>{' '}
-                    directive. For example, you can create a buffer of atomic counters:
-                    <pre style={{ color: theme.palette.neutral.main }}>
-                        #storage atomic_storage array&lt;atomic&lt;i32&gt;&gt;
-                    </pre>
-                    You could use WGSL&apos;s built-in functions to do atomic operations on this
-                    buffer in any order, enabling you to safely perform work across many threads at
-                    once and accumulate the result in one place. Note that any writes to read-write
-                    storage buffers are immediately visible to subsequent reads (unlike the
-                    situation with <HiLite>pass_in</HiLite> and <HiLite>pass_out</HiLite>).
-                    <br />
-                    <br />
-                    The final visual output of every shader is written to the{' '}
-                    <HiLite>screen</HiLite> storage texture, which displays the result in the canvas
-                    on this page.
-                    <br />
-                    <br />
-                    Debugging assertions are supported with an <HiLite>assert</HiLite> helper
-                    function:
-                    <pre style={{ color: theme.palette.neutral.main }}>
-                        assert(0, isfinite(col.x))
-                        <br />
-                        assert(1, isfinite(col.y))
-                    </pre>
-                    <h1>Examples</h1>
-                    <div style={{ fontWeight: 'bold', fontSize: '0.8rem' }}>
-                        <Link href={'https://compute.toys/view/77'} target="_blank">
-                            Simple single pass shader
-                        </Link>
-                        <br />
-                        <br />
-                        <Link href={'https://compute.toys/view/46'} target="_blank">
-                            Preprocessor #include
-                        </Link>
-                        <br />
-                        <br />
-                        <Link href={'https://compute.toys/view/59'} target="_blank">
-                            Terminal overlay
-                        </Link>
-                        <br />
-                        <br />
-                        <Link href={'https://compute.toys/view/76'} target="_blank">
-                            Storage usage
-                        </Link>
-                        <br />
-                        <br />
-                        <Link href={'https://compute.toys/view/25'} target="_blank">
-                            Workgroup shared memory
-                        </Link>
-                        <br />
-                        <br />
-                        <Link href={'https://compute.toys/view/48'} target="_blank">
-                            Preprocessor #dispatch_count
-                        </Link>
-                        <br />
-                        <br />
-                        <Link href={'https://compute.toys/view/47'} target="_blank">
-                            Preprocessor #workgroup_count
-                        </Link>
-                        <br />
-                        <br />
-                        <Link href={'https://compute.toys/view/17'} target="_blank">
-                            Assert
-                        </Link>
-                        <br />
-                        <br />
-                    </div>
-                    <h1>Prelude</h1>
-                    Every shader begins with a common <i>prelude</i>. The prelude contains the data
-                    inputs and outputs for this shader, as well as a few helper functions and type
-                    definitions to make working with <Logo /> a more streamlined and familiar
-                    process. Please refer to the prelude for a complete listing of the available
-                    data in your shader.
-                    <br />
-                    <br />
-                    Here are the current contents of this shader&apos;s prelude:
-                    <pre style={{ color: theme.palette.neutral.main }}>{prelude}</pre>
-                    <b>Note:</b> Matrix types in WGSL are stored in column-major order. This means a
-                    matrix of type <HiLite>mat2x3&lt;f32&gt;</HiLite> (aka <HiLite>mat2x3f</HiLite>{' '}
-                    or <HiLite>float2x3</HiLite>) is constructed from 2 column vectors of type{' '}
-                    <HiLite>vec3&lt;f32&gt;</HiLite> (aka <HiLite>vec3f</HiLite> or{' '}
-                    <HiLite>float3</HiLite>). This is backward from HLSL and convention in
-                    mathematics.
-                </div>
-            </Item>
-        </Draggable>
+            <Logo /> is a playground for WebGPU compute shaders. Everything here is written in WGSL,
+            which is WebGPU&apos;s native shader language. For up-to-date information on WGSL,
+            please see the <a href="https://www.w3.org/TR/WGSL/">WGSL draft specification</a>. You
+            can also <a href="https://google.github.io/tour-of-wgsl/">take a tour of WGSL</a>
+            .
+            <br />
+            <br />
+            <h1>Inputs</h1>
+            <Logo /> supplies keyboard input, mouse input, selectable input textures, custom values
+            controlled by sliders, and the current frame and elapsed time.
+            <br />
+            <br />
+            Mouse input can be accessed from the <HiLite>mouse</HiLite> struct:
+            <pre style={{ color: theme.palette.neutral.main }}>
+                mouse.pos: vec2i
+                <br />
+                mouse.click: i32
+            </pre>
+            Timing information is in the <HiLite>time</HiLite> struct:
+            <pre style={{ color: theme.palette.neutral.main }}>
+                time.frame: u32
+                <br />
+                time.elapsed: f32
+            </pre>
+            Custom uniforms are in the <HiLite>custom</HiLite> struct:
+            <pre style={{ color: theme.palette.neutral.main }}>
+                custom.my_custom_uniform_0: f32
+                <br />
+                custom.my_custom_uniform_1: f32
+            </pre>
+            Two selectable textures can be accessed from <HiLite>channel0</HiLite> and{' '}
+            <HiLite>channel1</HiLite>:
+            <pre style={{ color: theme.palette.neutral.main }}>
+                textureSampleLevel(channel0, bilinear, uv, pass, lod)
+                <br />
+                textureSampleLevel(channel1, bilinear, uv, pass, lod)
+            </pre>
+            Keyboard input can be accessed from the provided <HiLite>
+                keyDown(keycode: u32)
+            </HiLite>{' '}
+            helper function:
+            <pre style={{ color: theme.palette.neutral.main }}>
+                keyDown(32) // returns true when the spacebar is pressed
+            </pre>
+            <h1>Outputs</h1>
+            For compute shader input and output <Logo /> provides:
+            <br />
+            one input texture array <HiLite>pass_in</HiLite>,<br />
+            one output storage texture array <HiLite>pass_out</HiLite>,<br />
+            and one output screen storage texture <HiLite>screen</HiLite>.
+            <br />
+            <br />
+            The shader can write to <HiLite>pass_out</HiLite>, which will be copied into{' '}
+            <HiLite>pass_in</HiLite> after the current entrypoint has returned.
+            <HiLite> pass_in</HiLite> will always contain whatever has been written to{' '}
+            <HiLite>pass_out</HiLite> during all of the <em>previous</em> entrypoints. The contents
+            of <HiLite>pass_in</HiLite> will not change while an entrypoint is running.
+            <HiLite> pass_in</HiLite> and <HiLite>pass_out</HiLite> are both texture arrays with 4
+            texture layers. For example, you can access the third layer of <HiLite>pass_in</HiLite>{' '}
+            at LOD 0 and coordinate (1,1) by using the built-in helper function:
+            <br />
+            <pre style={{ color: theme.palette.neutral.main }}>passLoad(2, vec2i(1,1), 0)</pre>
+            <h1>Preprocessor</h1>
+            <Logo /> also provides an experimental WGSL preprocessor. It currently allows the use of
+            a handful of basic directives:
+            <ul>
+                <li>
+                    <HiLite>#define NAME VALUE</HiLite> for simple macros (function-like parameter
+                    substitution is not yet supported)
+                </li>
+                <li>
+                    <HiLite>#include &quot;PATH&quot;</HiLite> for accessing built-in libraries
+                </li>
+                <li>
+                    <HiLite>#workgroup_count ENTRYPOINT X Y Z</HiLite> for specifying how many
+                    workgroups should be dispatched for an entrypoint
+                </li>
+                <li>
+                    <HiLite>#dispatch_count ENTRYPOINT N</HiLite> for dispatching an entrypoint
+                    multiple times in a row
+                </li>
+                <li>
+                    <HiLite>#storage NAME TYPE</HiLite> for declaring a storage buffer
+                </li>
+            </ul>
+            <h1>Storage</h1>
+            Read-write storage buffers can be declared using the <HiLite>#storage</HiLite>{' '}
+            directive. For example, you can create a buffer of atomic counters:
+            <pre style={{ color: theme.palette.neutral.main }}>
+                #storage atomic_storage array&lt;atomic&lt;i32&gt;&gt;
+            </pre>
+            You could use WGSL&apos;s built-in functions to do atomic operations on this buffer in
+            any order, enabling you to safely perform work across many threads at once and
+            accumulate the result in one place. Note that any writes to read-write storage buffers
+            are immediately visible to subsequent reads (unlike the situation with{' '}
+            <HiLite>pass_in</HiLite> and <HiLite>pass_out</HiLite>).
+            <br />
+            <br />
+            The final visual output of every shader is written to the <HiLite>screen</HiLite>{' '}
+            storage texture, which displays the result in the canvas on this page.
+            <br />
+            <br />
+            Debugging assertions are supported with an <HiLite>assert</HiLite> helper function:
+            <pre style={{ color: theme.palette.neutral.main }}>
+                assert(0, isfinite(col.x))
+                <br />
+                assert(1, isfinite(col.y))
+            </pre>
+            <h1>Examples</h1>
+            <div style={{ fontWeight: 'bold', fontSize: '0.8rem' }}>
+                <Link href={'https://compute.toys/view/77'} target="_blank">
+                    Simple single pass shader
+                </Link>
+                <br />
+                <br />
+                <Link href={'https://compute.toys/view/46'} target="_blank">
+                    Preprocessor #include
+                </Link>
+                <br />
+                <br />
+                <Link href={'https://compute.toys/view/59'} target="_blank">
+                    Terminal overlay
+                </Link>
+                <br />
+                <br />
+                <Link href={'https://compute.toys/view/76'} target="_blank">
+                    Storage usage
+                </Link>
+                <br />
+                <br />
+                <Link href={'https://compute.toys/view/25'} target="_blank">
+                    Workgroup shared memory
+                </Link>
+                <br />
+                <br />
+                <Link href={'https://compute.toys/view/48'} target="_blank">
+                    Preprocessor #dispatch_count
+                </Link>
+                <br />
+                <br />
+                <Link href={'https://compute.toys/view/47'} target="_blank">
+                    Preprocessor #workgroup_count
+                </Link>
+                <br />
+                <br />
+                <Link href={'https://compute.toys/view/17'} target="_blank">
+                    Assert
+                </Link>
+                <br />
+                <br />
+            </div>
+            <h1>Prelude</h1>
+            Every shader begins with a common <i>prelude</i>. The prelude contains the data inputs
+            and outputs for this shader, as well as a few helper functions and type definitions to
+            make working with <Logo /> a more streamlined and familiar process. Please refer to the
+            prelude for a complete listing of the available data in your shader.
+            <br />
+            <br />
+            Here are the current contents of this shader&apos;s prelude:
+            <pre style={{ color: theme.palette.neutral.main }}>{prelude}</pre>
+            <b>Note:</b> Matrix types in WGSL are stored in column-major order. This means a matrix
+            of type <HiLite>mat2x3&lt;f32&gt;</HiLite> (aka <HiLite>mat2x3f</HiLite> or{' '}
+            <HiLite>float2x3</HiLite>) is constructed from 2 column vectors of type{' '}
+            <HiLite>vec3&lt;f32&gt;</HiLite> (aka <HiLite>vec3f</HiLite> or <HiLite>float3</HiLite>
+            ). This is backward from HLSL and convention in mathematics.
+        </div>
     );
 };
 
@@ -268,7 +211,9 @@ export default function Explainer() {
             >
                 <QuestionMarkIcon />
             </Button>
-            <DraggableExplainer hidden={explainerHidden} setHidden={setExplainerHidden} />
+            <DraggableWindow hidden={explainerHidden} setHidden={setExplainerHidden}>
+                <ExplainerBody />
+            </DraggableWindow>
         </Fragment>
     );
 }

--- a/components/global/draggable-window.tsx
+++ b/components/global/draggable-window.tsx
@@ -1,4 +1,5 @@
 import DisabledByDefaultSharp from '@mui/icons-material/DisabledByDefaultSharp';
+import Box from '@mui/material/Box';
 import { SxProps, Theme } from '@mui/material/styles';
 import {
     Dispatch,
@@ -93,8 +94,7 @@ export default function DraggableWindow({ children, hidden, setHidden, sx }: Dra
                                   position: 'fixed',
                                   left: '12%',
                                   top: '12%'
-                              },
-                        ...(Array.isArray(sx) ? sx : [sx])
+                              }
                     ]}
                 >
                     <div style={{ display: 'flex', gap: '2px' }}>
@@ -110,12 +110,12 @@ export default function DraggableWindow({ children, hidden, setHidden, sx }: Dra
                         {/* Annoying viewbox tweak to align with drag bar*/}
                         <DisabledByDefaultSharp
                             role="button"
-                            viewBox="1.5 1.5 19.5 20"
+                            viewBox="1 1.5 19.5 20"
                             onClick={() => setHidden(true)}
                             sx={{ cursor: 'pointer', color: 'rgba(150,150,150,1)' }}
                         />
                     </div>
-                    {children}
+                    <Box sx={sx}>{children}</Box>
                 </Item>
             </Draggable>
         </Fragment>

--- a/components/global/draggable-window.tsx
+++ b/components/global/draggable-window.tsx
@@ -8,6 +8,9 @@ interface DraggableWindowProps {
     children: ReactNode;
     hidden: boolean;
     setHidden: Dispatch<SetStateAction<boolean>>;
+    /**
+     * Optional styles to be applied to the <Item> content container
+     */
     sx?: SxProps<Theme>;
 }
 
@@ -44,19 +47,20 @@ export default function DraggableWindow({ children, hidden, setHidden, sx }: Dra
                         ...(Array.isArray(sx) ? sx : [sx])
                     ]}
                 >
-                    <div
-                        style={{
-                            display: 'flex',
-                            justifyContent: 'end',
-                            backgroundImage:
-                                'repeating-linear-gradient(-45deg, rgba(255,255,255, 0.25), rgba(255,255,255, 0.25) 2px, transparent 1px, transparent 6px)',
-                            backgroundSize: '4px 4px'
-                        }}
-                    >
+                    <div style={{ display: 'flex', gap: '2px' }}>
+                        <div
+                            id={handleId}
+                            style={{
+                                flex: 1,
+                                backgroundImage:
+                                    'repeating-linear-gradient(-45deg, rgba(255,255,255, 0.25), rgba(255,255,255, 0.25) 2px, transparent 1px, transparent 6px)',
+                                backgroundSize: '4px 4px'
+                            }}
+                        ></div>
                         {/* Annoying viewbox tweak to align with drag bar*/}
-                        <div style={{ width: '100%' }} id={handleId}></div>
                         <DisabledByDefaultSharp
-                            viewBox="1.5 1.5 19.5 19.5"
+                            role="button"
+                            viewBox="1.5 1.5 19.5 20"
                             onClick={() => setHidden(true)}
                             sx={{ cursor: 'pointer', color: 'rgba(150,150,150,1)' }}
                         />

--- a/components/global/draggable-window.tsx
+++ b/components/global/draggable-window.tsx
@@ -1,6 +1,5 @@
 import DisabledByDefaultSharp from '@mui/icons-material/DisabledByDefaultSharp';
-import { Theme } from '@mui/material';
-import { SxProps } from '@mui/material/styles';
+import { SxProps, Theme } from '@mui/material/styles';
 import { Dispatch, Fragment, ReactNode, SetStateAction, useId, useRef } from 'react';
 import Draggable from 'react-draggable';
 import { Item } from '../../theme/theme';
@@ -12,7 +11,6 @@ interface DraggableWindowProps {
     sx?: SxProps<Theme>;
 }
 
-// TODO: on Explainer, set an EXPLAINER_HEIGHT
 export default function DraggableWindow({ children, hidden, setHidden, sx }: DraggableWindowProps) {
     // Draggable needs this so React doesn't complain
     // about violating strict mode DOM access rules
@@ -41,7 +39,7 @@ export default function DraggableWindow({ children, hidden, setHidden, sx }: Dra
                                   display: 'inline-block',
                                   position: 'fixed',
                                   left: '12%',
-                                  top: '12%',
+                                  top: '12%'
                               },
                         ...(Array.isArray(sx) ? sx : [sx])
                     ]}

--- a/components/global/draggable-window.tsx
+++ b/components/global/draggable-window.tsx
@@ -97,7 +97,6 @@ export default function DraggableWindow({ children, hidden, setHidden, sx }: Dra
                         ...(Array.isArray(sx) ? sx : [sx])
                     ]}
                 >
-                    {zIndex}
                     <div style={{ display: 'flex', gap: '2px' }}>
                         <div
                             id={handleId}

--- a/components/global/draggable-window.tsx
+++ b/components/global/draggable-window.tsx
@@ -13,6 +13,7 @@ import {
 } from 'react';
 import Draggable from 'react-draggable';
 import { v4 as UUID } from 'uuid';
+import { cssEscape } from '../../lib/polyfills/cssescape';
 import { useWindowManagement } from '../../lib/util/draggablewindowscontext';
 import { Item } from '../../theme/theme';
 
@@ -44,7 +45,7 @@ export default function DraggableWindow({ children, hidden, setHidden, sx }: Dra
     // used for handle grab ID
     const handleId = useId();
     // useIds IDs include colons, which need escaping to be used with selectors
-    const handleSelector = `#${CSS.escape(handleId)}`;
+    const handleSelector = `#${cssEscape(handleId)}`;
 
     const { clear, add, moveToTop, uuidOrder } = useWindowManagement();
 

--- a/components/global/draggable-window.tsx
+++ b/components/global/draggable-window.tsx
@@ -1,0 +1,71 @@
+import DisabledByDefaultSharp from '@mui/icons-material/DisabledByDefaultSharp';
+import { Theme } from '@mui/material';
+import { SxProps } from '@mui/material/styles';
+import { Dispatch, Fragment, ReactNode, SetStateAction, useId, useRef } from 'react';
+import Draggable from 'react-draggable';
+import { Item } from '../../theme/theme';
+
+interface DraggableWindowProps {
+    children: ReactNode;
+    hidden: boolean;
+    setHidden: Dispatch<SetStateAction<boolean>>;
+    sx?: SxProps<Theme>;
+}
+
+// TODO: on Explainer, set an EXPLAINER_HEIGHT
+export default function DraggableWindow({ children, hidden, setHidden, sx }: DraggableWindowProps) {
+    // Draggable needs this so React doesn't complain
+    // about violating strict mode DOM access rules
+    const nodeRef = useRef(null);
+
+    const handleId = useId();
+    // useIds IDs include colons, which need escaping to be used with selectors
+    const handleSelector = `#${CSS.escape(handleId)}`;
+
+    return (
+        <Fragment>
+            <Draggable
+                handle={handleSelector}
+                nodeRef={nodeRef}
+                bounds="body"
+                positionOffset={{ x: '0', y: '0' }}
+            >
+                <Item
+                    ref={nodeRef}
+                    elevation={12}
+                    sx={[
+                        hidden
+                            ? { display: 'none' }
+                            : {
+                                  zIndex: '2',
+                                  display: 'inline-block',
+                                  position: 'fixed',
+                                  left: '12%',
+                                  top: '12%',
+                              },
+                        ...(Array.isArray(sx) ? sx : [sx])
+                    ]}
+                >
+                    <div
+                        style={{
+                            display: 'flex',
+                            justifyContent: 'end',
+                            backgroundImage:
+                                'repeating-linear-gradient(-45deg, rgba(255,255,255, 0.25), rgba(255,255,255, 0.25) 2px, transparent 1px, transparent 6px)',
+                            backgroundSize: '4px 4px'
+                        }}
+                    >
+                        {/* Annoying viewbox tweak to align with drag bar*/}
+                        <div style={{ width: '100%' }} id={handleId}></div>
+                        <DisabledByDefaultSharp
+                            viewBox="1.5 1.5 19.5 19.5"
+                            onClick={() => setHidden(true)}
+                            sx={{ cursor: 'pointer', color: 'rgba(150,150,150,1)' }}
+                        />
+                    </div>
+                    {children}
+                </Item>
+            </Draggable>
+        </Fragment>
+    );
+}

--- a/lib/polyfills/cssescape.ts
+++ b/lib/polyfills/cssescape.ts
@@ -1,0 +1,81 @@
+/**
+ * Derived from Polyfill linked on MDN for CSS.escape due to SSR
+ * https://developer.mozilla.org/en-US/docs/Web/API/CSS/escape_static
+ *
+ * Next.js hints at being able to add custom "proper" polyfill, which would be ideal
+ * https://nextjs.org/docs/architecture/supported-browsers
+ */
+
+/*! https://mths.be/cssescape v1.5.1 by @mathias | MIT license */
+export const cssEscape = function (value) {
+    if (arguments.length === 0) {
+        throw new TypeError('`CSS.escape` requires an argument.');
+    }
+    const string = String(value);
+    const length = string.length;
+    let index = -1;
+    let codeUnit;
+    let result = '';
+    const firstCodeUnit = string.charCodeAt(0);
+
+    if (
+        // If the character is the first character and is a `-` (U+002D), and
+        // there is no second character, […]
+        length === 1 &&
+        firstCodeUnit === 0x002d
+    ) {
+        return '\\' + string;
+    }
+
+    while (++index < length) {
+        codeUnit = string.charCodeAt(index);
+        // Note: there’s no need to special-case astral symbols, surrogate
+        // pairs, or lone surrogates.
+
+        // If the character is NULL (U+0000), then the REPLACEMENT CHARACTER
+        // (U+FFFD).
+        if (codeUnit === 0x0000) {
+            result += '\uFFFD';
+            continue;
+        }
+
+        if (
+            // If the character is in the range [\1-\1F] (U+0001 to U+001F) or is
+            // U+007F, […]
+            (codeUnit >= 0x0001 && codeUnit <= 0x001f) ||
+            codeUnit === 0x007f ||
+            // If the character is the first character and is in the range [0-9]
+            // (U+0030 to U+0039), […]
+            (index === 0 && codeUnit >= 0x0030 && codeUnit <= 0x0039) ||
+            // If the character is the second character and is in the range [0-9]
+            // (U+0030 to U+0039) and the first character is a `-` (U+002D), […]
+            (index === 1 && codeUnit >= 0x0030 && codeUnit <= 0x0039 && firstCodeUnit === 0x002d)
+        ) {
+            // https://drafts.csswg.org/cssom/#escape-a-character-as-code-point
+            result += '\\' + codeUnit.toString(16) + ' ';
+            continue;
+        }
+
+        // If the character is not handled by one of the above rules and is
+        // greater than or equal to U+0080, is `-` (U+002D) or `_` (U+005F), or
+        // is in one of the ranges [0-9] (U+0030 to U+0039), [A-Z] (U+0041 to
+        // U+005A), or [a-z] (U+0061 to U+007A), […]
+        if (
+            codeUnit >= 0x0080 ||
+            codeUnit === 0x002d ||
+            codeUnit === 0x005f ||
+            (codeUnit >= 0x0030 && codeUnit <= 0x0039) ||
+            (codeUnit >= 0x0041 && codeUnit <= 0x005a) ||
+            (codeUnit >= 0x0061 && codeUnit <= 0x007a)
+        ) {
+            // the character itself
+            result += string.charAt(index);
+            continue;
+        }
+
+        // Otherwise, the escaped character.
+        // https://drafts.csswg.org/cssom/#escape-a-character
+        result += '\\' + string.charAt(index);
+    }
+    return result;
+};

--- a/lib/util/draggablewindowscontext.tsx
+++ b/lib/util/draggablewindowscontext.tsx
@@ -1,0 +1,60 @@
+import { createContext, useContext, useState } from 'react';
+
+interface WindowManagementContextInterface {
+    clear: (uuid: string) => void;
+    add: (uuid: string) => void;
+    moveToTop: (uuid: string) => void;
+    uuidOrder: string[];
+}
+
+const WindowManagementContext = createContext<WindowManagementContextInterface>(undefined);
+
+export const WindowManagementProvider = ({ ...props }) => {
+    const [uuids, setUuids] = useState<string[]>([]);
+
+    const clear = async (uuid: string) => {
+        setUuids(uuids.filter(handle => handle !== uuid));
+    };
+
+    const add = (uuid: string) => {
+        setUuids(previous => {
+            const uuidsCp = [...previous];
+            const idx = uuidsCp.indexOf(uuid);
+            if (idx < 0) {
+                return [uuid, ...uuidsCp];
+            }
+            return [...uuidsCp];
+        });
+    };
+
+    const moveToTop = (uuid: string) => {
+        setUuids(previous => {
+            const uuidsCp = [...previous];
+            const currentIndex = uuidsCp.indexOf(uuid);
+            if (currentIndex >= 0) {
+                uuidsCp.splice(uuidsCp.indexOf(uuid), 1);
+            }
+            return [uuid, ...uuidsCp];
+        });
+    };
+
+    return (
+        <WindowManagementContext.Provider
+            value={{
+                clear,
+                add,
+                moveToTop,
+                uuidOrder: uuids
+            }}
+            {...props}
+        />
+    );
+};
+
+export const useWindowManagement = () => {
+    const context = useContext(WindowManagementContext);
+    if (context === undefined) {
+        throw new Error('useAuth must be used within an AuthProvider');
+    }
+    return context;
+};

--- a/lib/util/draggablewindowscontext.tsx
+++ b/lib/util/draggablewindowscontext.tsx
@@ -54,7 +54,7 @@ export const WindowManagementProvider = ({ ...props }) => {
 export const useWindowManagement = () => {
     const context = useContext(WindowManagementContext);
     if (context === undefined) {
-        throw new Error('useAuth must be used within an AuthProvider');
+        throw new Error('useWindowManagement must be used within an WindowManagementProvider');
     }
     return context;
 };

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -5,9 +5,9 @@ import FavIconHead from 'components/global/faviconhead';
 import LoginModal from 'components/global/loginmodal';
 import { ShadowCanvas } from 'components/global/shadowcanvas';
 import { AuthProvider } from 'lib/db/authcontext';
+import { WindowManagementProvider } from 'lib/util/draggablewindowscontext';
 import type { AppProps } from 'next/app';
 import { theme } from 'theme/theme';
-import { WindowManagementProvider } from '../lib/util/draggablewindowscontext';
 
 export default function App({ Component, pageProps }: AppProps) {
     return (

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -7,18 +7,21 @@ import { ShadowCanvas } from 'components/global/shadowcanvas';
 import { AuthProvider } from 'lib/db/authcontext';
 import type { AppProps } from 'next/app';
 import { theme } from 'theme/theme';
+import { WindowManagementProvider } from '../lib/util/draggablewindowscontext';
 
 export default function App({ Component, pageProps }: AppProps) {
     return (
         <AuthProvider>
-            <ThemeProvider theme={theme}>
-                <FavIconHead />
-                <ShadowCanvas />
-                <CssBaseline />
-                <LoginModal />
-                <Component {...pageProps} />
-                <Footer />
-            </ThemeProvider>
+            <WindowManagementProvider>
+                <ThemeProvider theme={theme}>
+                    <FavIconHead />
+                    <ShadowCanvas />
+                    <CssBaseline />
+                    <LoginModal />
+                    <Component {...pageProps} />
+                    <Footer />
+                </ThemeProvider>
+            </WindowManagementProvider>
         </AuthProvider>
     );
 }


### PR DESCRIPTION
- Modularized the draggable windows
  - Created a `DraggableWindow` window component, removing reuse of the window background/x button/drag handle styling code in the `TexturePicker` and the `Explainer` 
  - Stylized draggable windows can now be simply created like the following:
    ```
    <DraggableWindow hidden={hidden} setHidden={setHidden}>
      <div>I can be dragged around</div>
    </DraggableWindow>```
- Added a `WindowManagementProvider` which tracks the state of the most recently clicked/opened window and ensures it is on top of the other windows (has a higher z-index)
  - The draggables now act more like Windows or MacOS; if you have both the explainer and the texture picker open, and they are overlapping, clicking on the window that is behind the other one brings it to the front
- Fixed issue with title bar rendering
  - The pattern no longer clips behind the "X" button
  - ![image](https://github.com/user-attachments/assets/1ab17c43-053b-404d-9456-ea3122c2060a)
  - I think this was the original intention given the flexbox styling on the parent

Let me know if this is too much for one PR, I can cherry pick the commits out into two or three branches

