### PR TITLE
Fix code scanning alert no. 1: Use of `Kernel.open` or `IO.read` or similar sinks with a non-constant value

### DIFF
--- a/screenshot.rb
+++ b/screenshot.rb
@@ -4,6 +4,7 @@ require 'base64'
 require 'fileutils'
 require 'json'
 require 'open-uri'
+require 'net/http'
 require 'rest-client'
 require 'screenshot'
 require 'tmpdir'
@@ -124,7 +125,7 @@ begin
     end
 
     puts "Downloading from: #{image_url}"
-    image_data = URI.open(image_url).read
+    image_data = Net::HTTP.get(URI.parse(image_url))
     save_locally(screenshot, image_data)
 
     if ENV['GITHUB_TOKEN']


### PR DESCRIPTION
Fixes [https://github.com/compute-toys/compute.toys/security/code-scanning/1](https://github.com/compute-toys/compute.toys/security/code-scanning/1)

To fix the problem, we should replace the use of `URI.open` with a safer alternative that does not call `Kernel.open` internally. Specifically, we can use `Net::HTTP.get` to fetch the image data from the URL. This approach avoids the security risks associated with `Kernel.open`.

We need to:
1. Replace the `URI.open(image_url).read` call with `Net::HTTP.get(URI.parse(image_url))`.
2. Ensure that the `net/http` library is required at the beginning of the file.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
