### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,4 +1,6 @@
 name: Build
+permissions:
+  contents: read
 on:
   push:
     branches: [master]


### PR DESCRIPTION
Potential fix for [https://github.com/compute-toys/compute.toys/security/code-scanning/2](https://github.com/compute-toys/compute.toys/security/code-scanning/2)

To fix the issue, we will add a `permissions` block at the root level of the workflow file. This block will explicitly set the permissions for the `GITHUB_TOKEN` to `contents: read`, which is sufficient for the operations performed in this workflow. This change ensures that the workflow adheres to the principle of least privilege and avoids granting unnecessary write permissions.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
