### PR TITLE
change mouse Y direction in shadertoy.slang

### DIFF
--- a/lib/shaders/shadertoy.slang
+++ b/lib/shaders/shadertoy.slang
@@ -138,7 +138,7 @@ public static const vec3 iResolution = vec3(SCREEN_SIZE, 1);
 public static float iTime = time.elapsed;
 public static float iTimeDelta = time.delta;
 public static int iFrame = time.frame;
-public static vec4 iMouse = vec4(mouse.pos.x, SCREEN_SIZE.y - 1 - mouse.pos.y, mouse.start.x, SCREEN_SIZE.y - 1 - mouse.start.y);
+public static vec4 iMouse = vec4(mouse.pos.xy, mouse.start.xy);
 
 public vec4 texelFetch(int channel, ivec2 coord, int lod) {
     return pass_in[ivec3(coord, channel)];


### PR DESCRIPTION
Proposing to change in shadertoy.slang and Shadertoy template by MichaelMoroz too.
Reason: sampling in textures Y down in WebGPU. Example: https://compute.toys/view/2086