### PR TITLE
Fixes `WGSLError: invalid #dispatch_count syntax` when using `[DispatchOnce]` in slang

### DIFF
--- a/lib/slang/glue.ts
+++ b/lib/slang/glue.ts
@@ -171,8 +171,8 @@ class ShaderConverter {
     private generateDispatchDirectives(entryPoints: ReflectionEntryPoint[]): string {
         return entryPoints
             .filter(ep => ep.userAttribs?.some(attr => attr.name === 'DispatchOnce'))
-            .map(ep => `#dispatch_once ${ep.name}`)
-            .join('\n');
+            .map(ep => `#dispatch_once ${ep.name}\n`)
+            .join('');
     }
 
     public convert(input: EnhancedReflectionJSON, channelDimensions: TextureDimensions[]): string {


### PR DESCRIPTION
The error was a missing newline after final `#dispatch_once` directive generated by slang glue code.

The previous solution could lead to no newline at the end of the generated slang prelude, causing the main file and prelude to be merged on a single line, triggering issues with the custom `handle_dispatch_once` function which only expects 2 tokens, however gets more than expected (which also is incorrect, as the tokens were not separated at all) and thus causes a `WGSLError('Invalid #dispatch_count syntax')`.

This is what causes the error observed by oneshade [VAMP] - 10.07.2025 03:35 on discord, and is subsequently fixed by this.
Their code to test this was:
```slang
import std;

struct Layer {
    float x;
};

[StorageBuffer(1)]
RWStructuredBuffer<Layer> layers;

[shader("compute")]
[DispatchOnce]
[numthreads(16, 16, 1)]
void main(uint3 id : SV_DispatchThreadID) {
    layers[0] = Layer(0.0);
    screen[id.xy] = float4(1.0);
}
```

[master@fa98d6d](https://github.com/compute-toys/compute.toys/commit/fa98d6d9b53c2df38c7d403bc0dca4f2e55cfb76)
runs into the error, this PR fixes it.