### PR TITLE
Workflow does not contain permissions

### DIFF
--- a/.github/workflows/supabase-ci.yml
+++ b/.github/workflows/supabase-ci.yml
@@ -1,4 +1,6 @@
 name: Supabase CI
+permissions:
+  contents: read
 
 on:
   push:

--- a/.github/workflows/supabase-production.yml
+++ b/.github/workflows/supabase-production.yml
@@ -1,4 +1,6 @@
 name: Deploy Migrations to Production
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/compute-toys/compute.toys/security/code-scanning/5](https://github.com/compute-toys/compute.toys/security/code-scanning/5)

To fix the problem, explicitly set the `permissions` block in the workflow file to restrict the `GITHUB_TOKEN` to the minimum required privileges. Since the workflow appears to only check out code and run tests (with no evidence of writing to the repository, creating issues, or modifying pull requests), the minimal required permission is likely `contents: read`. This can be set at the workflow level (applies to all jobs) or at the job level (applies only to the specific job). The best practice is to add the following at the top level of the workflow file, just after the `name` field and before `on`:

```yaml
permissions:
  contents: read
```

No additional methods, imports, or definitions are needed.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
