### PR TITLE
Fixed keyboard inputs to shaders

### DIFF
--- a/components/wgputoycontroller.tsx
+++ b/components/wgputoycontroller.tsx
@@ -556,6 +556,8 @@ const WgpuToyController = props => {
 
             const handlePointerDown = (e: MouseEvent | TouchEvent) => {
                 if (isPointerPressed()) return;
+                // Focus the canvas to enable keyboard events
+                if (canvas instanceof HTMLCanvasElement) canvas.focus();
                 setIsPointerPressed(true);
                 previousPointerStart = ComputeEngine.getInstance().getMousePos();
                 const p = getPointerPosition(e);


### PR DESCRIPTION
To update the `_keyboard` struct we need to process the corresponding `keyDown` and `keyUp` events.
These events are only processed if they bubble through the canvas.
As such the canvas needs to be focused, otherwise the keyboard inputs are not used to update the `_keyboard` struct.
This PR simply allows the user to focus the canvas by clicking on it.

TBH I'm don't think this is the best solution, but it definitely works as a quick workaround.
The reasons why I don't fully like this solution:

- There is no indication whether the canvas is focused or not ~> users might not know why the keyboard input works in some instances and why it doesn't in others
- You need to explicitly focus the canvas by clicking on it. I reckon it would be better to instead capture the events on something like the container or `window` instead, i.e. if no other _thing_ captures the key events, they should go to the canvas instead. I tried registering to `window` but found that it would capture too many events: i.e. when typing in the search, the metadata text boxes or the monaco editor, it would still capture the events. 
This over-capturing is rather annoying as well hence this PR only has the more conservative method implemented instead, capturing only actual canvas events. I assume the other way would require the corresponding other input fields to actually capture the events, and I'm too lazy right now to do a proper implementation, finding all other relevant input boxes on that page :P