### PR TITLE
fix displayP3 color space conversion

### DIFF
--- a/lib/engine/blit.ts
+++ b/lib/engine/blit.ts
@@ -46,7 +46,7 @@ fn linear_to_displayp3(color: vec3f) -> vec3f {
         vec3f(0.177538,  0.9668058, 0.0723974), // Col 1
         vec3f(0.0,       0.0,       0.9105199)  // Col 2
     );
-    return linear_to_srgb(linSRGB_to_linP3 * color);
+    return linear_to_srgb(color);
 }
 
 @fragment


### PR DESCRIPTION
i did not know compute.toys saved color space option per shader
with this fix if a user selects displayP3 in a shader then the output of that shader has to be displayP3
before this fix it was assuming all shaders outputs as sRGB but correctly tranformed to show into displayP3 when displayP3 selected